### PR TITLE
Add Employee entity and API

### DIFF
--- a/ShopChain.Api/Controllers/EmployeesController.cs
+++ b/ShopChain.Api/Controllers/EmployeesController.cs
@@ -1,0 +1,48 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using ShopChain.Application.Commands;
+using ShopChain.Application.Queries;
+using ShopChain.Core.Entities;
+
+namespace ShopChain.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EmployeesController(ISender sender) : ControllerBase
+    {
+        [HttpGet]
+        public async Task<IActionResult> GetAllEmployees()
+        {
+            var result = await sender.Send(new GetAllEmployeesQuery());
+            return Ok(result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetEmployeeById(int id)
+        {
+            var result = await sender.Send(new GetEmployeeByID(id));
+            return result is not null ? Ok(result) : NotFound();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateEmployee([FromBody] Employee employee)
+        {
+            var result = await sender.Send(new AddEmployeeCommand(employee));
+            return CreatedAtAction(nameof(GetEmployeeById), new { id = result!.EmployeeID }, result);
+        }
+
+        [HttpPut]
+        public async Task<IActionResult> UpdateEmployee([FromBody] Employee employee)
+        {
+            var result = await sender.Send(new UpdateEmployeeCommand(employee));
+            return result is not null ? Ok(result) : NotFound();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteEmployee(int id)
+        {
+            var result = await sender.Send(new DeleteEmployeeCommand(id));
+            return result ? NoContent() : NotFound();
+        }
+    }
+}

--- a/ShopChain.Api/DependencyInjection.cs
+++ b/ShopChain.Api/DependencyInjection.cs
@@ -10,7 +10,7 @@ namespace ShopChain.Api
         {
             services
                 .AddApplicationDI()
-                .AddInfranstructureDI(configuration)
+                .AddInfrastructureDI(configuration)
                 .AddCoreDI();
 
             //services.AddControllers().AddJsonOptions(options =>

--- a/ShopChain.Application/Commands/AddEmployeeCommand.cs
+++ b/ShopChain.Application/Commands/AddEmployeeCommand.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using ShopChain.Core.Entities;
+using ShopChain.Core.Interfaces;
+
+namespace ShopChain.Application.Commands
+{
+    public record AddEmployeeCommand(Employee Employee) : IRequest<Employee?>;
+
+    public class AddEmployeeCommandHandler(IEmployeeRepository employeeRepository) : IRequestHandler<AddEmployeeCommand, Employee?>
+    {
+        public async Task<Employee?> Handle(AddEmployeeCommand request, CancellationToken cancellationToken)
+        {
+            return await employeeRepository.AddEmployeeAsync(request.Employee);
+        }
+    }
+}

--- a/ShopChain.Application/Commands/DeleteEmployeeCommand.cs
+++ b/ShopChain.Application/Commands/DeleteEmployeeCommand.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using ShopChain.Core.Interfaces;
+
+namespace ShopChain.Application.Commands
+{
+    public record DeleteEmployeeCommand(int Id) : IRequest<bool>;
+
+    public class DeleteEmployeeCommandHandler(IEmployeeRepository employeeRepository) : IRequestHandler<DeleteEmployeeCommand, bool>
+    {
+        public async Task<bool> Handle(DeleteEmployeeCommand request, CancellationToken cancellationToken)
+        {
+            return await employeeRepository.DeleteEmployeeAsync(request.Id);
+        }
+    }
+}

--- a/ShopChain.Application/Commands/UpdateEmployeeCommand.cs
+++ b/ShopChain.Application/Commands/UpdateEmployeeCommand.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using ShopChain.Core.Entities;
+using ShopChain.Core.Interfaces;
+
+namespace ShopChain.Application.Commands
+{
+    public record UpdateEmployeeCommand(Employee Employee) : IRequest<Employee?>;
+
+    public class UpdateEmployeeCommandHandler(IEmployeeRepository employeeRepository) : IRequestHandler<UpdateEmployeeCommand, Employee?>
+    {
+        public async Task<Employee?> Handle(UpdateEmployeeCommand request, CancellationToken cancellationToken)
+        {
+            return await employeeRepository.UpdateEmployeeAsync(request.Employee);
+        }
+    }
+}

--- a/ShopChain.Application/Queries/GetAllEmployeesQuery.cs
+++ b/ShopChain.Application/Queries/GetAllEmployeesQuery.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using ShopChain.Core.Entities;
+using ShopChain.Core.Interfaces;
+
+namespace ShopChain.Application.Queries
+{
+    public record GetAllEmployeesQuery() : IRequest<List<Employee>>;
+
+    public class GetAllEmployeesQueryHandler(IEmployeeRepository employeeRepository) : IRequestHandler<GetAllEmployeesQuery, List<Employee>>
+    {
+        public async Task<List<Employee>> Handle(GetAllEmployeesQuery request, CancellationToken cancellationToken)
+        {
+            return await employeeRepository.GetAllEmployeesAsync();
+        }
+    }
+}

--- a/ShopChain.Application/Queries/GetEmployeeByID.cs
+++ b/ShopChain.Application/Queries/GetEmployeeByID.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using ShopChain.Core.Entities;
+using ShopChain.Core.Interfaces;
+
+namespace ShopChain.Application.Queries
+{
+    public record GetEmployeeByID(int Id) : IRequest<Employee?>;
+
+    public class GetEmployeeByIDHandler(IEmployeeRepository employeeRepository) : IRequestHandler<GetEmployeeByID, Employee?>
+    {
+        public async Task<Employee?> Handle(GetEmployeeByID request, CancellationToken cancellationToken)
+        {
+            return await employeeRepository.GetEmployeeByIdAsync(request.Id);
+        }
+    }
+}

--- a/ShopChain.Core/Entities/Employee.cs
+++ b/ShopChain.Core/Entities/Employee.cs
@@ -1,0 +1,21 @@
+namespace ShopChain.Core.Entities
+{
+    public class Employee
+    {
+        public int EmployeeID { get; set; }
+
+        public string FullName { get; set; } = null!;
+
+        public string Email { get; set; } = null!;
+
+        public string PhoneNumber { get; set; } = null!;
+
+        public string Position { get; set; } = null!;
+
+        public bool IsDeleted { get; set; } = false;
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime? UpdatedAt { get; set; }
+    }
+}

--- a/ShopChain.Core/Interfaces/IEmployeeRepository.cs
+++ b/ShopChain.Core/Interfaces/IEmployeeRepository.cs
@@ -1,0 +1,13 @@
+using ShopChain.Core.Entities;
+
+namespace ShopChain.Core.Interfaces
+{
+    public interface IEmployeeRepository
+    {
+        Task<Employee?> AddEmployeeAsync(Employee employee);
+        Task<Employee?> UpdateEmployeeAsync(Employee employee);
+        Task<bool> DeleteEmployeeAsync(int id);
+        Task<Employee?> GetEmployeeByIdAsync(int id);
+        Task<List<Employee>> GetAllEmployeesAsync();
+    }
+}

--- a/ShopChain.Infrastructure/Data/AppDbContext.cs
+++ b/ShopChain.Infrastructure/Data/AppDbContext.cs
@@ -5,6 +5,7 @@ namespace ShopChain.Infrastructure.Data
     public class AppDbContext(DbContextOptions<AppDbContext> options): DbContext(options)
     {
         public DbSet<Core.Entities.Store> Stores { get; set; } = null!;
+        public DbSet<Core.Entities.Employee> Employees { get; set; } = null!;
         public DbSet<Core.Entities.Ward> Wards { get; set; } = null!;
         public DbSet<Core.Entities.District> Districts { get; set; } = null!;
         public DbSet<Core.Entities.Province> Provinces { get; set; } = null!;

--- a/ShopChain.Infrastructure/DependencyInjection.cs
+++ b/ShopChain.Infrastructure/DependencyInjection.cs
@@ -10,7 +10,7 @@ namespace ShopChain.Infrastructure
 {
     public static class DependencyInjection
     {
-        public static IServiceCollection AddInfrastructureDI(this IServiceCollection services)
+        public static IServiceCollection AddInfrastructureDI(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddDbContext<AppDbContext>(options =>
             {
@@ -18,6 +18,7 @@ namespace ShopChain.Infrastructure
             });
 
             services.AddScoped<IStoreRepository, StoreRepository>();
+            services.AddScoped<IEmployeeRepository, EmployeeRepository>();
 
             services.AddScoped<IExternalVendorRepository, ExternalVendorRepository>();
 

--- a/ShopChain.Infrastructure/Repositories/EmployeeRepository.cs
+++ b/ShopChain.Infrastructure/Repositories/EmployeeRepository.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using ShopChain.Core.Entities;
+using ShopChain.Core.Interfaces;
+using ShopChain.Infrastructure.Data;
+
+namespace ShopChain.Infrastructure.Repositories
+{
+    public class EmployeeRepository(AppDbContext context) : IEmployeeRepository
+    {
+        public async Task<List<Employee>> GetAllEmployeesAsync()
+        {
+            return await context.Employees
+                .Where(e => !e.IsDeleted)
+                .ToListAsync();
+        }
+
+        public async Task<Employee?> GetEmployeeByIdAsync(int id)
+        {
+            return await context.Employees
+                .Where(e => e.EmployeeID == id && !e.IsDeleted)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<Employee?> AddEmployeeAsync(Employee employee)
+        {
+            await context.Employees.AddAsync(employee);
+            await context.SaveChangesAsync();
+            return employee;
+        }
+
+        public async Task<Employee?> UpdateEmployeeAsync(Employee employee)
+        {
+            context.Employees.Update(employee);
+            await context.SaveChangesAsync();
+            return employee;
+        }
+
+        public async Task<bool> DeleteEmployeeAsync(int id)
+        {
+            var employee = await context.Employees.FindAsync(id);
+            if (employee == null || employee.IsDeleted)
+            {
+                return false;
+            }
+            employee.IsDeleted = true;
+            employee.UpdatedAt = DateTime.UtcNow;
+            await context.SaveChangesAsync();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Employee entity and repository
- expose Employee CRUD commands/queries via MediatR
- register Employee services in DI
- expose EmployeesController endpoints

## Testing
- `dotnet build ShopChain.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842617a468483289e90dbaa0db9f2f4